### PR TITLE
Separating OVN NB and SB database processes

### DIFF
--- a/debian/ovn-central.init
+++ b/debian/ovn-central.init
@@ -28,12 +28,18 @@ start () {
     "$@" || exit $?
 }
 
+stop_northd () {
+    set /usr/share/openvswitch/scripts/ovn-ctl ${1-stop_northd}
+    set "$@" $OVN_CTL_OPTS
+    "$@" || exit $?
+}
+
 case $1 in
     start)
         start
         ;;
     stop)
-        /usr/share/openvswitch/scripts/ovn-ctl stop_northd
+        stop_northd
         ;;
     restart)
         start restart_northd

--- a/ovn/northd/ovn-northd.c
+++ b/ovn/northd/ovn-northd.c
@@ -52,7 +52,8 @@ struct northd_context {
 static const char *ovnnb_db;
 static const char *ovnsb_db;
 
-static const char *default_db(void);
+static const char *default_nb_db(void);
+static const char *default_sb_db(void);
 
 /* Pipeline stages. */
 
@@ -168,7 +169,7 @@ Options:\n\
   -h, --help                display this help message\n\
   -o, --options             list available options\n\
   -V, --version             display version information\n\
-", program_name, program_name, default_db(), default_db());
+", program_name, program_name, default_nb_db(), default_sb_db());
     daemon_usage();
     vlog_usage();
     stream_usage("database", true, true, false);
@@ -1922,15 +1923,26 @@ ovnsb_db_run(struct northd_context *ctx)
 }
 
 
-static char *default_db_;
+static char *default_nb_db_;
 
 static const char *
-default_db(void)
+default_nb_db(void)
 {
-    if (!default_db_) {
-        default_db_ = xasprintf("unix:%s/db.sock", ovs_rundir());
+    if (!default_nb_db_) {
+        default_nb_db_ = xasprintf("unix:%s/ovnnb_db.sock", ovs_rundir());
     }
-    return default_db_;
+    return default_nb_db_;
+}
+
+static char *default_sb_db_;
+
+static const char *
+default_sb_db(void)
+{
+    if (!default_sb_db_) {
+        default_sb_db_ = xasprintf("unix:%s/ovnsb_db.sock", ovs_rundir());
+    }
+    return default_sb_db_;
 }
 
 static void
@@ -1992,11 +2004,11 @@ parse_options(int argc OVS_UNUSED, char *argv[] OVS_UNUSED)
     }
 
     if (!ovnsb_db) {
-        ovnsb_db = default_db();
+        ovnsb_db = default_sb_db();
     }
 
     if (!ovnnb_db) {
-        ovnnb_db = default_db();
+        ovnnb_db = default_nb_db();
     }
 
     free(short_options);
@@ -2112,7 +2124,8 @@ main(int argc, char *argv[])
     ovsdb_idl_loop_destroy(&ovnsb_idl_loop);
     service_stop();
 
-    free(default_db_);
+    free(default_nb_db_);
+    free(default_sb_db_);
     exit(res);
 }
 

--- a/ovn/utilities/ovn-ctl
+++ b/ovn/utilities/ovn-ctl
@@ -30,32 +30,79 @@ done
 ## start ##
 ## ----- ##
 
-upgrade_ovn_dbs () {
-    ovn_dbs=$(ovs-appctl -t ovsdb-server ovsdb-server/list-dbs 2>/dev/null)
-    for db in $ovn_dbs; do
-        case $db in
-            OVN*)
-                action "Removing $db from ovsdb-server" \
-                    ovs-appctl -t ovsdb-server ovsdb-server/remove-db $db
-                ;;
-        esac
-    done
-    upgrade_db "$DB_NB_FILE" "$DB_NB_SCHEMA"
-    upgrade_db "$DB_SB_FILE" "$DB_SB_SCHEMA"
-    for db in $DB_NB_FILE $DB_SB_FILE; do
-        action "Adding $db to ovsdb-server" \
-            ovs-appctl -t ovsdb-server ovsdb-server/add-db $db || exit 1
-    done
+pidfile_is_running () {
+    pidfile=$1
+    test -e "$pidfile" && pid=`cat "$pidfile"` && pid_exists "$pid"
+} >/dev/null 2>&1
+
+stop_ovsdb () {
+    if pidfile_is_running $DB_NB_PID; then
+        ovs-appctl -t ovnnb_db exit
+    fi
+
+    if pidfile_is_running $DB_SB_PID; then
+        ovs-appctl -t ovnsb_db exit
+    fi
+}
+
+start_ovsdb () {
+    # Check and eventually start ovsdb-server for Northbound DB
+    if ! pidfile_is_running $DB_NB_PID; then
+        upgrade_db "$DB_NB_FILE" "$DB_NB_SCHEMA" 1>/dev/null 2>/dev/null
+
+        set ovsdb-server
+
+        set "$@" --detach $OVN_NB_LOG --log-file=$OVN_NB_LOGFILE --remote=punix:$DB_NB_SOCK --remote=ptcp:$DB_NB_PORT --pidfile=$DB_NB_PID --unixctl=ovnnb_db
+
+        $@ $DB_NB_FILE
+    fi
+
+    # Check and eventually start ovsdb-server for Southbound DB
+    if ! pidfile_is_running $DB_SB_PID; then
+        upgrade_db "$DB_SB_FILE" "$DB_SB_SCHEMA" 1>/dev/null 2>/dev/null
+
+        set ovsdb-server
+
+        set "$@" --detach $OVN_SB_LOG --log-file=$OVN_SB_LOGFILE --remote=punix:$DB_SB_SOCK --remote=ptcp:$DB_SB_PORT --pidfile=$DB_SB_PID --unixctl=ovnsb_db
+        $@ $DB_SB_FILE
+    fi
+}
+
+status_ovsdb () {
+  if ! pidfile_is_running $DB_NB_PID; then
+      log_success_msg "OVN Northbound DB is not running"
+  else
+      log_success_msg "OVN Northbound DB is running"
+  fi
+
+  if ! pidfile_is_running $DB_SB_PID; then
+      log_success_msg "OVN Southbound DB is not running"
+  else
+      log_success_msg "OVN Southbound DB is running"
+  fi
 }
 
 start_northd () {
-    # We expect ovn-northd to be co-located with ovsdb-server handling both the
-    # OVN_Northbound and OVN_Southbound dbs.
-    upgrade_ovn_dbs
+  if test X"$OVN_MANAGE_OVSDB" = Xyes; then
+      start_ovsdb
+  fi
 
-    set ovn-northd
-    set "$@" -vconsole:emer -vsyslog:err -vfile:info
-    OVS_RUNDIR=${OVN_RUNDIR} start_daemon "$OVN_NORTHD_PRIORITY" "$OVN_NORTHD_WRAPPER" "$@"
+  if ! pidfile_is_running $DB_NB_PID; then
+      log_failure_msg "OVN Northbound DB is not running"
+      exit
+  fi
+  if ! pidfile_is_running $DB_SB_PID; then
+      log_failure_msg "OVN Southbound DB is not running"
+      exit
+  fi
+
+  if daemon_is_running ovn-northd; then
+      log_success_msg "OVN Northbound is already running"
+  else
+      set ovn-northd
+      set "$@" $OVN_NORTHD_LOG --ovnnb-db=unix:$DB_NB_SOCK --ovnsb-db=unix:$DB_SB_SOCK
+      OVS_RUNDIR=${OVN_RUNDIR} start_daemon "$OVN_NORTHD_PRIORITY" "$OVN_NORTHD_WRAPPER" "$@"
+  fi
 }
 
 start_controller () {
@@ -70,6 +117,10 @@ start_controller () {
 
 stop_northd () {
     OVS_RUNDIR=${OVN_RUNDIR} stop_daemon ovn-northd
+
+    if test X"$OVN_MANAGE_OVSDB" = Xyes; then
+        stop_ovsdb
+    fi
 }
 
 stop_controller () {
@@ -90,16 +141,34 @@ restart_controller () {
     start_controller
 }
 
+restart_ovsdb () {
+    stop_ovsdb
+    start_ovsdb
+}
+
 ## ---- ##
 ## main ##
 ## ---- ##
 
 set_defaults () {
-    DB_SOCK=$rundir/db.sock
-    DB_NB_FILE=$dbdir/ovnnb.db
-    DB_SB_FILE=$dbdir/ovnsb.db
+    OVN_DIR=$rundir
+    OVN_MANAGE_OVSDB=yes
+
+    DB_NB_SOCK=$OVN_DIR/ovnnb_db.sock
+    DB_NB_PID=$OVN_DIR/ovnnb_db.pid
+    DB_NB_FILE=$OVN_DIR/ovnnb_db.db
+    DB_NB_PORT=6641
+
+    DB_SB_SOCK=$OVN_DIR/ovnsb_db.sock
+    DB_SB_PID=$OVN_DIR/ovnsb_db.pid
+    DB_SB_FILE=$OVN_DIR/ovnsb_db.db
+    DB_SB_PORT=6642
+
     DB_NB_SCHEMA=$datadir/ovn-nb.ovsschema
     DB_SB_SCHEMA=$datadir/ovn-sb.ovsschema
+
+    DB_SOCK=$rundir/db.sock
+    DB_CONF_FILE=$dbdir/conf.db
 
     OVN_NORTHD_PRIORITY=-10
     OVN_NORTHD_WRAPPER=
@@ -108,6 +177,13 @@ set_defaults () {
 
     OVS_RUNDIR=${OVS_RUNDIR:-${rundir}}
     OVN_RUNDIR=${OVN_RUNDIR:-${OVS_RUNDIR}}
+
+    OVN_CONTROLLER_LOG="-vconsole:emer -vsyslog:err -vfile:info"
+    OVN_NORTHD_LOG="-vconsole:emer -vsyslog:err -vfile:info"
+    OVN_NB_LOG="-vconsole:off"
+    OVN_SB_LOG="-vconsole:off"
+    OVN_NB_LOGFILE="$OVS_LOGDIR/ovsdb-server-nb.log"
+    OVN_SB_LOGFILE="$OVS_LOGDIR/ovsdb-server-sb.log"
 }
 
 set_option () {
@@ -134,10 +210,13 @@ startup scripts.  System administrators should not normally invoke it directly.
 
 Commands:
   start_northd           start ovn-northd
+  start_ovsdb            start ovn related ovsdb-server processes
   start_controller       start ovn-controller
   stop_northd            stop ovn-northd
+  stop_ovsdb             stop ovn related ovsdb-server processes
   stop_controller        stop ovn-controller
   restart_northd         restart ovn-northd
+  restart_ovsdb          restart ovn related ovsdb-server processes
   restart_controller     restart ovn-controller
 
 Options:
@@ -145,6 +224,11 @@ Options:
   --ovn-northd-wrapper=WRAPPER   run with a wrapper like valgrind for debugging
   --ovn-controller-priority=NICE     set ovn-northd's niceness (default: $OVN_CONTROLLER_PRIORITY)
   --ovn-controller-wrapper=WRAPPER   run with a wrapper like valgrind for debugging
+  --ovn-manage-ovsdb=no              manage ovsdb separately from start_northd and stop_northd
+  --ovn-controller-log=STRING        ovn controller process logging params (default: $OVN_CONTROLLER_LOG)
+  --ovn-northd-log=STRING            ovn northd process logging params (default: $OVN_NORTHD_LOG)
+  --ovn-nb-log=STRING             ovn NB ovsdb-server processes logging params (default: $OVN_NB_LOG)
+  --ovn-sb-log=STRING             ovn SB ovsdb-server processes logging params (default: $OVN_SB_LOG)
   -h, --help                     display this help message
 
 File location options:
@@ -153,6 +237,11 @@ File location options:
   --db-sb-file=FILE    OVN_Southbound db file (default: $DB_SB_FILE)
   --db-nb-schema=FILE  OVN_Northbound db file (default: $DB_NB_SCHEMA)
   --db-sb-schema=FILE  OVN_Southbound db file (default: $DB_SB_SCHEMA)
+  --db-nb-port=PORT    OVN Northbound db ptcp port (default: $DB_NB_PORT)
+  --db-sb-port=PORT    OVN Southbound db ptcp port (default: $DB_SB_PORT)
+  --ovn-dir=FILE       OVN Databases directory (default: $OVN_DIR)
+  --ovn-nb-logfile=FILE OVN Northbound log file (default: $OVS_LOGDIR/ovsdb-server-nb.log)
+  --ovn-sb-logfile=FILE OVN Southbound log file (default: $OVS_LOGDIR/ovsdb-server-sb.log)
 
 Default directories with "configure" option and environment variable override:
   logs: /usr/local/var/log/openvswitch (--with-logdir, OVS_LOGDIR)
@@ -210,11 +299,17 @@ case $command in
     start_northd)
         start_northd
         ;;
+    start_ovsdb)
+        start_ovsdb
+        ;;
     start_controller)
         start_controller
         ;;
     stop_northd)
         stop_northd
+        ;;
+    stop_ovsdb)
+       stop_ovsdb
         ;;
     stop_controller)
         stop_controller
@@ -222,11 +317,17 @@ case $command in
     restart_northd)
         restart_northd
         ;;
+    restart_ovsdb)
+        restart_ovsdb
+        ;;
     restart_controller)
         restart_controller
         ;;
     status_northd)
         daemon_status ovn-northd || exit 1
+        ;;
+    status_ovsdb)
+        status_ovsdb
         ;;
     status_controller)
         daemon_status ovn-controller || exit 1

--- a/ovn/utilities/ovn-nbctl.c
+++ b/ovn/utilities/ovn-nbctl.c
@@ -142,7 +142,7 @@ nbctl_default_db(void)
     if (!def) {
         def = getenv("OVN_NB_DB");
         if (!def) {
-            def = ctl_default_db();
+            def = xasprintf("unix:%s/ovnnb_db.sock", ovs_rundir());
         }
     }
     return def;

--- a/ovn/utilities/ovn-sbctl.c
+++ b/ovn/utilities/ovn-sbctl.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 
 #include "db-ctl-base.h"
+#include "dirs.h"
 
 #include "command-line.h"
 #include "compiler.h"
@@ -154,7 +155,7 @@ sbctl_default_db(void)
     if (!def) {
         def = getenv("OVN_SB_DB");
         if (!def) {
-            def = ctl_default_db();
+            def = xasprintf("unix:%s/ovnsb_db.sock", ovs_rundir());
         }
     }
     return def;

--- a/tests/ovn-controller-vtep.at
+++ b/tests/ovn-controller-vtep.at
@@ -24,8 +24,10 @@ m4_define([OVN_CONTROLLER_VTEP_START],
    done
 
    dnl Start ovsdb-server.
-   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile --log-file --remote=punix:$OVS_RUNDIR/db.sock vswitchd.db vtep.db ovn-nb.db ovn-sb.db], [0], [], [stderr])
-   on_exit "kill `cat ovsdb-server.pid`"
+   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile=$OVS_RUNDIR/ovsdb-server.pid --log-file --remote=punix:$OVS_RUNDIR/db.sock vswitchd.db vtep.db], [0], [], [stderr])
+   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile=$OVS_RUNDIR/ovsdb-nb-server.pid --log-file=ovsdb-nb-server.log --remote=punix:$OVS_RUNDIR/ovnnb_db.sock ovn-nb.db], [0], [], [stderr])
+   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile=$OVS_RUNDIR/ovsdb-sb-server.pid --log-file=ovsdb-sb-server.log --remote=punix:$OVS_RUNDIR/ovnsb_db.sock ovn-sb.db ovn-sb.db], [0], [], [stderr])
+   on_exit "kill `cat ovsdb-server.pid` `cat ovsdb-nb-server.pid` `cat ovsdb-sb-server.pid`"
    AT_CHECK([[sed < stderr '
 /vlog|INFO|opened log file/d
 /ovsdb_server|INFO|ovsdb-server (Open vSwitch)/d']])
@@ -58,14 +60,14 @@ m4_define([OVN_CONTROLLER_VTEP_START],
 
    dnl Start ovn-northd.
    AT_CHECK([ovn-nbctl lswitch-add br-test])
-   AT_CHECK([ovn-northd --detach --pidfile --log-file --ovnnb-db=unix:$OVS_RUNDIR/db.sock --ovnsb-db=unix:$OVS_RUNDIR/db.sock], [0], [], [stderr])
+   AT_CHECK([ovn-northd --detach --pidfile --log-file], [0], [], [stderr])
    on_exit "kill `cat ovn-northd.pid`"
    AT_CHECK([[sed < stderr '
 /vlog|INFO|opened log file/d']])
    AT_CAPTURE_FILE([ovn-northd.log])
 
    dnl Start ovn-controllger-vtep.
-   AT_CHECK([ovn-controller-vtep --detach --pidfile --log-file --vtep-db=unix:$OVS_RUNDIR/db.sock --ovnsb-db=unix:$OVS_RUNDIR/db.sock], [0], [], [stderr])
+   AT_CHECK([ovn-controller-vtep --detach --pidfile --log-file --vtep-db=unix:$OVS_RUNDIR/db.sock --ovnsb-db=unix:$OVS_RUNDIR/ovnsb_db.sock], [0], [], [stderr])
    AT_CAPTURE_FILE([ovn-controller-vtep.log])
    on_exit "kill `cat ovn-controller-vtep.pid`"
    AT_CHECK([[sed < stderr '
@@ -103,6 +105,7 @@ m4_define([OVN_CONTROLLER_VTEP_STOP],
 # $4: logical switch name on vtep gateway chassis
 m4_define([OVN_NB_ADD_VTEP_PORT], [
 AT_CHECK([ovn-nbctl lport-add $1 $2])
+
 AT_CHECK([ovn-nbctl lport-set-type $2 vtep])
 AT_CHECK([ovn-nbctl lport-set-options $2 vtep-physical-switch=$3 vtep-logical-switch=$4])
 ])

--- a/tests/ovn-nbctl.at
+++ b/tests/ovn-nbctl.at
@@ -7,7 +7,7 @@ m4_define([OVN_NBCTL_TEST_START],
    AT_CHECK([ovsdb-tool create ovn-nb.db $abs_top_srcdir/ovn/ovn-nb.ovsschema])
 
    dnl Start ovsdb-server.
-   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile --log-file --remote=punix:$OVS_RUNDIR/db.sock ovn-nb.db], [0], [], [stderr])
+   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile --log-file --remote=punix:$OVS_RUNDIR/ovnnb_db.sock ovn-nb.db], [0], [], [stderr])
    on_exit "kill `cat ovsdb-server.pid`"
    AT_CHECK([[sed < stderr '
 /vlog|INFO|opened log file/d

--- a/tests/ovn-sbctl.at
+++ b/tests/ovn-sbctl.at
@@ -8,16 +8,17 @@ m4_define([OVN_SBCTL_TEST_START],
       AT_CHECK([ovsdb-tool create $daemon.db $abs_top_srcdir/${daemon%%-*}/${daemon}.ovsschema])
    done
 
-   dnl Start ovsdb-server.
-   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile --log-file --remote=punix:$OVS_RUNDIR/db.sock ovn-nb.db ovn-sb.db], [0], [], [stderr])
-   on_exit "kill `cat ovsdb-server.pid`"
+   dnl Start ovsdb-servers.
+   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile=$OVS_RUNDIR/ovnnb_db.pid --log-file=$OVS_RUNDIR/ovsdb_nb.log --remote=punix:$OVS_RUNDIR/ovnnb_db.sock ovn-nb.db ], [0], [], [stderr])
+   AT_CHECK([ovsdb-server --detach --no-chdir --pidfile=$OVS_RUNDIR/ovnsb_db.pid --log-file=$OVS_RUNDIR/ovsdb_sb.log --remote=punix:$OVS_RUNDIR/ovnsb_db.sock ovn-sb.db], [0], [], [stderr])
+   on_exit "kill `cat ovnnb_db.pid` `cat ovnsb_db.pid`"
    AT_CHECK([[sed < stderr '
 /vlog|INFO|opened log file/d
 /ovsdb_server|INFO|ovsdb-server (Open vSwitch)/d']])
    AT_CAPTURE_FILE([ovsdb-server.log])
 
    dnl Start ovn-northd.
-   AT_CHECK([ovn-northd --detach --pidfile --log-file --ovnnb-db=unix:$OVS_RUNDIR/db.sock --ovnsb-db=unix:$OVS_RUNDIR/db.sock], [0], [], [stderr])
+   AT_CHECK([ovn-northd --detach --pidfile --log-file --ovnnb-db=unix:$OVS_RUNDIR/ovnnb_db.sock --ovnsb-db=unix:$OVS_RUNDIR/ovnsb_db.sock], [0], [], [stderr])
    on_exit "kill `cat ovn-northd.pid`"
    AT_CHECK([[sed < stderr '
 /vlog|INFO|opened log file/d']])
@@ -36,7 +37,8 @@ m4_define([OVN_SBCTL_TEST_STOP],
    AT_CHECK([check_logs "$1
 /Broken pipe/d"])
    AT_CHECK([ovs-appctl -t ovn-northd exit])
-   AT_CHECK([ovs-appctl -t ovsdb-server exit])])
+   AT_CHECK([ovs-appctl --target=$OVS_RUNDIR/ovsdb-server.`cat ovnnb_db.pid`.ctl exit])
+   AT_CHECK([ovs-appctl --target=$OVS_RUNDIR/ovsdb-server.`cat ovnsb_db.pid`.ctl exit])])
 
 dnl ---------------------------------------------------------------------
 

--- a/tutorial/ovs-sandbox
+++ b/tutorial/ovs-sandbox
@@ -318,10 +318,22 @@ if $ovn; then
     run ovsdb-tool create ovnsb.db "$ovnsb_schema"
     run ovsdb-tool create ovnnb.db "$ovnnb_schema"
     run ovsdb-tool create vtep.db "$vtep_schema"
-    ovsdb_server_args="ovnsb.db ovnnb.db vtep.db conf.db"
+    ovsdb_server_args="vtep.db conf.db"
+    ovsdb_sb_server_args="ovnsb.db"
+    ovsdb_nb_server_args="ovnnb.db"
 fi
 rungdb $gdb_ovsdb $gdb_ovsdb_ex ovsdb-server --detach --no-chdir --pidfile -vconsole:off --log-file \
     --remote=punix:"$sandbox"/db.sock $ovsdb_server_args
+if $ovn; then
+    rungdb $gdb_ovsdb $gdb_ovsdb_ex ovsdb-server --detach --no-chdir \
+        --pidfile="$sandbox"/ovnnb_db.pid -vconsole:off \
+        --log-file="$sandbox"/ovnnb_db.log \
+        --remote=punix:"$sandbox"/ovnnb_db.sock $ovsdb_nb_server_args
+    rungdb $gdb_ovsdb $gdb_ovsdb_ex ovsdb-server --detach --no-chdir \
+        --pidfile="$sandbox"/ovnsb_db.pid -vconsole:off \
+        --log-file="$sandbox"/ovnsb_db.log \
+        --remote=punix:"$sandbox"/ovnsb_db.sock $ovsdb_sb_server_args
+fi
 
 #Add a small delay to allow ovsdb-server to launch.
 sleep 0.1
@@ -344,13 +356,19 @@ rungdb $gdb_vswitchd $gdb_vswitchd_ex ovs-vswitchd --detach --no-chdir --pidfile
 
 if $ovn; then
     ovs-vsctl set open . external-ids:system-id=56b18105-5706-46ef-80c4-ff20979ab068
-    ovs-vsctl set open . external-ids:ovn-remote=unix:"$sandbox"/db.sock
+    ovs-vsctl set open . external-ids:ovn-remote=unix:"$sandbox"/ovnsb_db.sock
     ovs-vsctl set open . external-ids:ovn-encap-type=geneve
     ovs-vsctl set open . external-ids:ovn-encap-ip=127.0.0.1
 
-    rungdb $gdb_ovn_northd $gdb_ovn_northd_ex ovn-northd --detach --no-chdir --pidfile -vconsole:off --log-file
-    rungdb $gdb_ovn_controller $gdb_ovn_controller_ex ovn-controller --detach --no-chdir --pidfile -vconsole:off --log-file
-    rungdb $gdb_ovn_controller_vtep $gdb_ovn_controller_vtep_ex ovn-controller-vtep --detach --no-chdir --pidfile -vconsole:off --log-file
+    rungdb $gdb_ovn_northd $gdb_ovn_northd_ex ovn-northd --detach \
+        --no-chdir --pidfile -vconsole:off --log-file \
+        --ovnsb-db=unix:"$sandbox"/ovnsb_db.sock \
+        --ovnnb-db=unix:"$sandbox"/ovnnb_db.sock
+    rungdb $gdb_ovn_controller $gdb_ovn_controller_ex ovn-controller \
+        --detach --no-chdir --pidfile -vconsole:off --log-file 
+    rungdb $gdb_ovn_controller_vtep $gdb_ovn_controller_vtep_ex \
+        ovn-controller-vtep --detach --no-chdir --pidfile -vconsole:off \
+        --log-file --ovnsb-db=unix:"$sandbox"/ovnsb_db.sock
 fi
 
 cat <<EOF


### PR DESCRIPTION
OVN NB & SB DB's should be run in separate ovsdb-server processes
and should run with ovn-ctl start_northd / stop_northd.  This patch
includes changes to unit tests, tutorial and debian scripts to remain
self-consistent.

Signed-off-by: RYAN D. MOATS rmoats@us.ibm.com
